### PR TITLE
Disable caching in get_cd_by_wid

### DIFF
--- a/narratives/napoleon/input.py
+++ b/narratives/napoleon/input.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from time import time
 import os
 import csv
 import re
@@ -196,9 +197,7 @@ with open("data.csv", mode="r") as narrative_file:
             "img": row["pics"].splitlines()[0] if row["pics"] else "",
         }
         get_cd_by_wid = lambda wid: requests.get(
-            os.getenv("API_ROOT", "http://localhost/api/")
-            + "/cached-data?wikidata_id="
-            + wid
+            f"{os.getenv('API_ROOT', 'http://localhost/api/')}/cached-data?wikidata_id={wid}&{int(time())}"
         ).json()
         narration_data["attached_events_ids"] = list(
             filter(


### PR DESCRIPTION
Before exceptions were being thrown when attempting to use the same event in attached_events columns if it didn't already exist in the db.